### PR TITLE
Added name field to metadata for Berks 3.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,10 @@
+name              "apt"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Configures apt and apt services and an LWRP for managing apt repositories"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.3.2"
+version           "1.3.3"
 recipe            "apt", "Runs apt-get update during compile phase and sets up preseed directories"
 recipe            "apt::cacher-ng", "Set up an apt-cacher-ng caching proxy"
 recipe            "apt::cacher-client", "Client for the apt::cacher-ng caching proxy"


### PR DESCRIPTION
Added a name field to the metadata for compatibility with Berkshelf 3.3.0 after receiving this message during a test-kitchen run:

> ```
>   Resolving cookbook dependencies with Berkshelf 3.3.0...
> ```
> 
>  ------Exception-------
>  Class: Kitchen::ActionFailed
> Message: Failed to complete #converge action: [The following error occurred while reading the 
> cookbook `apt':
> Ridley::Errors::MissingNameAttribute: The metadata at 
> '/var/folders/v0/xzf4f5tx7_z3d2z9fjgg3lvh0000gn/T/d20151112-16408-1ymo9nd' does not contain a
> 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a > valid metadata 'name' entry.]
